### PR TITLE
Fixed CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # credicard.js
 
-[![Build Status](https://api.travis-ci.org/DomPhysis/credicard.js.svg?branch=master)](https://travis-ci.org/DomPhysis/credicard.js)
+[![Build Status](https://api.travis-ci.org/ContaAzul/credicard.js.svg?branch=master)](https://travis-ci.org/ContaAzul/credicard.js)
 
 > A simple credit cards validation library in JavaScript.
 


### PR DESCRIPTION
It was being pointed to the original repo, under DomPhysis org, which is now just wrong.

Fixed it to be under ContaAzul.